### PR TITLE
Quest monster level ranges

### DIFF
--- a/src/damage/damage.ts
+++ b/src/damage/damage.ts
@@ -58,7 +58,7 @@ export function calculateDamage(
     ?.hitzones.at(hitzoneIndex);
   if (!maybeHitzone) {
     throw new Error(
-      `${monsterName}, monsterStateIndex ${monsterStateIndex} does not have a hitzone at index ${hitzoneIndex}`
+      `'${monsterName}', monsterStateIndex '${monsterStateIndex}' does not have a hitzone at index '${hitzoneIndex}'`
     );
   }
 
@@ -111,7 +111,7 @@ export function calculateDamage(
       );
     }
     default: {
-      throw new Error(`${weaponClass} is not a valid weapon type`);
+      throw new Error(`'${weaponClass}' is not a valid weapon type`);
     }
   }
 }

--- a/src/damage/damage.ts
+++ b/src/damage/damage.ts
@@ -1,4 +1,4 @@
-import { MonsterLevels, Monsters, Weapons, type MonsterTypes } from '../model';
+import { Monsters, Weapons, type MonsterTypes } from '../model';
 import type {
   DamageBuffArgs,
   GreatSwordDamageArgs,
@@ -44,7 +44,12 @@ export function calculateDamage(
   damageBuffArgs: Partial<DamageBuffArgs>
 ) {
   const { weaponClass } = weaponArgs;
-  const { monsterName, questId, monsterStateIndex, hitzoneIndex } = monsterArgs;
+  const {
+    monsterName,
+    monsterStatMultipliers,
+    monsterStateIndex,
+    hitzoneIndex
+  } = monsterArgs;
   const monster = Monsters.getMonster(monsterName);
 
   // Validate parameters
@@ -59,10 +64,7 @@ export function calculateDamage(
 
   const monsterMultipliers: MonsterMultipliers = {
     hitzoneValues: maybeHitzone.values,
-    levelMultipliers:
-      questId === undefined
-        ? MonsterLevels.getMonsterStatMultipliers(monsterName, 0)
-        : MonsterLevels.getMonsterMultipliersForQuest(monsterName, questId)
+    statMultipliers: monsterStatMultipliers
   };
 
   switch (weaponClass) {

--- a/src/damage/damage.ts
+++ b/src/damage/damage.ts
@@ -61,7 +61,7 @@ export function calculateDamage(
     hitzoneValues: maybeHitzone.values,
     levelMultipliers:
       questId === undefined
-        ? MonsterLevels.getMonsterLevelMultipliers(monsterName, 0)
+        ? MonsterLevels.getMonsterStatMultipliers(monsterName, 0)
         : MonsterLevels.getMonsterMultipliersForQuest(monsterName, questId)
   };
 

--- a/src/damage/types.ts
+++ b/src/damage/types.ts
@@ -1,4 +1,4 @@
-import type { MonsterLevelTypes, QuestTypes } from '../model';
+import type { MonsterLevelTypes } from '../model';
 import type { MonsterTypes } from '../model/monsters';
 import type {
   GreatSwordTypes,
@@ -106,8 +106,8 @@ export type WeaponArgs =
  */
 export interface MonsterArgs {
   readonly monsterName: MonsterTypes.MonsterName;
-  /** Quest featuring this monster */
-  readonly questId: QuestTypes.Quest['id'] | undefined;
+  /** Contains multipliers for monster health, defense, and stagger limit */
+  readonly monsterStatMultipliers: MonsterLevelTypes.MonsterStatMultipliers;
   /** Must be valid monster state for this monsters */
   readonly monsterStateIndex: number;
   /** Must be valid index for the provided monsterStateIndex */
@@ -122,7 +122,7 @@ export interface MonsterMultipliers {
   /** Derived from Monster hitzone */
   readonly hitzoneValues: MonsterTypes.HitzoneValues;
   /** Derived from Monster level set by Quest */
-  readonly levelMultipliers: MonsterLevelTypes.MonsterStatMultipliers;
+  readonly statMultipliers: MonsterLevelTypes.MonsterStatMultipliers;
 }
 
 /**

--- a/src/damage/types.ts
+++ b/src/damage/types.ts
@@ -122,7 +122,7 @@ export interface MonsterMultipliers {
   /** Derived from Monster hitzone */
   readonly hitzoneValues: MonsterTypes.HitzoneValues;
   /** Derived from Monster level set by Quest */
-  readonly levelMultipliers: MonsterLevelTypes.MonsterLevelMultipliers;
+  readonly levelMultipliers: MonsterLevelTypes.MonsterStatMultipliers;
 }
 
 /**

--- a/src/damage/util/damage-util.ts
+++ b/src/damage/util/damage-util.ts
@@ -209,7 +209,7 @@ export function getRawMultiplier(
  */
 export function applyDefenseMultiplier(
   damage: number,
-  defenseMultiplier: MonsterLevelTypes.MonsterLevelMultipliers['defense']
+  defenseMultiplier: MonsterLevelTypes.MonsterStatMultipliers['defense']
 ) {
   return Math.floor(Math.floor(damage) * defenseMultiplier);
 }
@@ -289,7 +289,7 @@ export function calculateIsolatedElementalDamage({
   elementArgs = defaultElementArgs,
   defenseMultiplier
 }: ElementalDamageArgs & {
-  defenseMultiplier: MonsterLevelTypes.MonsterLevelMultipliers['defense'];
+  defenseMultiplier: MonsterLevelTypes.MonsterStatMultipliers['defense'];
 }) {
   return applyDefenseMultiplier(
     calculateElementalDamage({

--- a/src/damage/util/damage-util.ts
+++ b/src/damage/util/damage-util.ts
@@ -57,7 +57,7 @@ export function validateWeaponSharpness(
   const validSharpness = sharpness <= weapon.sharpnessUp.length - 1;
   if (!validSharpness) {
     throw new Error(
-      `${weapon.name} cannot have ${Weapons.sharpnessAsString(sharpness)} sharpness`
+      `'${weapon.name}' cannot have '${Weapons.sharpnessAsString(sharpness)}' sharpness`
     );
   }
   return validSharpness;
@@ -83,7 +83,7 @@ export function getSharpnessRawMultiplier(sharpness: Sharpness): number {
     case Sharpness.PURPLE:
       return 1.5;
     default:
-      throw new Error(`Invalid sharpness value ${sharpness}`);
+      throw new Error(`Invalid sharpness value '${sharpness}'`);
   }
 }
 
@@ -107,7 +107,7 @@ export function getSharpnessElementalMultiplier(sharpness: Sharpness): number {
     case Sharpness.PURPLE:
       return 1.2;
     default:
-      throw new Error(`Invalid sharpness value ${sharpness}`);
+      throw new Error(`Invalid sharpness value '${sharpness}'`);
   }
 }
 
@@ -138,7 +138,7 @@ function getHitzoneForWeaponElement(
     case 'dragon':
       return hitzoneValues.dragon;
     default:
-      throw new Error(`Invalid hitzone type ${weaponElement}`);
+      throw new Error(`Invalid hitzone type '${weaponElement}'`);
   }
 }
 

--- a/src/damage/util/great-sword-damage.ts
+++ b/src/damage/util/great-sword-damage.ts
@@ -86,7 +86,8 @@ export function calculateGreatSwordDamage(
   damageBuffArgs: Partial<DamageBuffArgs>
 ) {
   const { weaponId, attackName, sharpness, weaponMultipliers } = weaponArgs;
-  const { hitzoneValues, levelMultipliers } = monsterMultipliers;
+  const { hitzoneValues, statMultipliers: levelMultipliers } =
+    monsterMultipliers;
   const { rawArgs, elementArgs, weaponClassArgs } = damageBuffArgs;
 
   const greatSword = Weapons.getWeapon(

--- a/src/damage/util/great-sword-damage.ts
+++ b/src/damage/util/great-sword-damage.ts
@@ -36,7 +36,7 @@ function getGreatSwordAttack(
   const result = gsAttacks.attacks.find(atk => atk.name === attackName);
   if (!result) {
     throw new Error(
-      `${attackName} is not a valid ${WeaponClass.GREAT_SWORD} attack`
+      `'${attackName}' is not a valid '${WeaponClass.GREAT_SWORD}' attack`
     );
   }
   return result as WeaponTypes.Attack<GreatSwordTypes.GreatSwordAttack>;
@@ -73,7 +73,7 @@ function validateGreatSword(
   weapon: WeaponTypes.Weapon
 ): asserts weapon is GreatSwordTypes.GreatSword {
   if (weapon.type !== WeaponClass.GREAT_SWORD) {
-    throw new Error(`${weapon.name} is not a ${WeaponClass.GREAT_SWORD}`);
+    throw new Error(`'${weapon.name}' is not a '${WeaponClass.GREAT_SWORD}'`);
   }
 }
 

--- a/src/damage/util/hammer-damage.ts
+++ b/src/damage/util/hammer-damage.ts
@@ -54,7 +54,8 @@ export function calculateHammerDamage(
   damageBuffArgs: Partial<DamageBuffArgs>
 ) {
   const { weaponId, attackName, sharpness } = weaponArgs;
-  const { hitzoneValues, levelMultipliers } = monsterMultipliers;
+  const { hitzoneValues, statMultipliers: levelMultipliers } =
+    monsterMultipliers;
   const { rawArgs, elementArgs, weaponClassArgs } = damageBuffArgs;
 
   const hammer = Weapons.getWeapon(Weapons.WeaponClass.HAMMER, weaponId);

--- a/src/damage/util/hammer-damage.ts
+++ b/src/damage/util/hammer-damage.ts
@@ -31,7 +31,7 @@ function getHammerAttack(
   const result = hammerAttacks.attacks.find(atk => atk.name === attackName);
   if (!result) {
     throw new Error(
-      `${attackName} is not a valid ${WeaponClass.HAMMER} attack`
+      `'${attackName}' is not a valid '${WeaponClass.HAMMER}' attack`
     );
   }
   return result as WeaponTypes.Attack<HammerTypes.HammerAttack>;
@@ -41,7 +41,7 @@ function validateHammer(
   weapon: WeaponTypes.Weapon
 ): asserts weapon is HammerTypes.Hammer {
   if (weapon.type !== WeaponClass.HAMMER) {
-    throw new Error(`${weapon.name} is not a ${WeaponClass.HAMMER}`);
+    throw new Error(`'${weapon.name}' is not a '${WeaponClass.HAMMER}'`);
   }
 }
 

--- a/src/damage/util/lance-damage.ts
+++ b/src/damage/util/lance-damage.ts
@@ -73,7 +73,8 @@ export function calculateLanceDamage(
   damageBuffArgs: Partial<DamageBuffArgs>
 ) {
   const { weaponId, attackName, sharpness } = weaponArgs;
-  const { hitzoneValues, levelMultipliers } = monsterMultipliers;
+  const { hitzoneValues, statMultipliers: levelMultipliers } =
+    monsterMultipliers;
   const { rawArgs, elementArgs, weaponClassArgs } = damageBuffArgs;
 
   const lance = Weapons.getWeapon(Weapons.WeaponClass.LANCE, weaponId);

--- a/src/damage/util/lance-damage.ts
+++ b/src/damage/util/lance-damage.ts
@@ -35,7 +35,7 @@ function getLanceAttack(
 
   const result = lanceAttacks.attacks.find(atk => atk.name === attackName);
   if (!result) {
-    throw new Error(`${attackName} is not a valid Lance attack`);
+    throw new Error(`'${attackName}' is not a valid Lance attack`);
   }
   return result as WeaponTypes.Attack<LanceTypes.LanceAttack>;
 }
@@ -60,7 +60,7 @@ function validateLance(
   weapon: WeaponTypes.Weapon
 ): asserts weapon is LanceTypes.Lance {
   if (weapon.type !== WeaponClass.LANCE) {
-    throw new Error(`${weapon.name} is not a ${WeaponClass.LANCE}`);
+    throw new Error(`'${weapon.name}' is not a '${WeaponClass.LANCE}'`);
   }
 }
 

--- a/src/damage/util/longsword-damage.ts
+++ b/src/damage/util/longsword-damage.ts
@@ -83,7 +83,8 @@ export function calculateLongswordDamage(
 ) {
   const { weaponId, attackName, sharpness } = weaponArgs;
   const { longsword: longswordArgs } = weaponArgs.weaponMultipliers;
-  const { hitzoneValues, levelMultipliers } = monsterMultipliers;
+  const { hitzoneValues, statMultipliers: levelMultipliers } =
+    monsterMultipliers;
   const { rawArgs, elementArgs, weaponClassArgs } = damageBuffArgs;
 
   const longsword = Weapons.getWeapon(Weapons.WeaponClass.LONGSWORD, weaponId);

--- a/src/damage/util/longsword-damage.ts
+++ b/src/damage/util/longsword-damage.ts
@@ -36,7 +36,7 @@ function getLongwordAttack(
 
   const result = lsAttack.attacks.find(atk => atk.name === attackName);
   if (!result) {
-    throw new Error(`${attackName} is not valid Longsword attack`);
+    throw new Error(`'${attackName}' is not valid Longsword attack`);
   }
   return result as WeaponTypes.Attack<LongswordTypes.LongswordAttack>;
 }
@@ -69,7 +69,7 @@ function validateLongsword(
   weapon: WeaponTypes.Weapon
 ): asserts weapon is LongswordTypes.Longsword {
   if (weapon.type !== WeaponClass.LONGSWORD) {
-    throw new Error(`${weapon.name} is not a ${WeaponClass.LONGSWORD}`);
+    throw new Error(`'${weapon.name}' is not a '${WeaponClass.LONGSWORD}'`);
   }
 }
 

--- a/src/damage/util/switch-axe-damage.ts
+++ b/src/damage/util/switch-axe-damage.ts
@@ -113,7 +113,8 @@ export function calculateSwitchAxeDamage(
 ) {
   const { weaponId, attackName, sharpness } = weaponArgs;
   const { switchAxeMode } = weaponArgs.weaponMultipliers;
-  const { hitzoneValues, levelMultipliers } = monsterMultipliers;
+  const { hitzoneValues, statMultipliers: levelMultipliers } =
+    monsterMultipliers;
   const { rawArgs, elementArgs, weaponClassArgs } = damageBuffArgs;
 
   const switchAxe = Weapons.getWeapon(Weapons.WeaponClass.SWITCH_AXE, weaponId);

--- a/src/damage/util/switch-axe-damage.ts
+++ b/src/damage/util/switch-axe-damage.ts
@@ -34,12 +34,12 @@ function getSwitchAxeAttack(
   ).attackModes.find(atkGroup => atkGroup.name === switchAxeMode);
 
   if (!switchAxeAttacks) {
-    throw new Error(`${switchAxeMode} is not a valid switch axe mode`);
+    throw new Error(`'${switchAxeMode}' is not a valid switch axe mode`);
   }
   const result = switchAxeAttacks.attacks.find(atk => atk.name === attackName);
   if (!result) {
     throw new Error(
-      `${attackName} is not a valid Switch Axe attack for ${switchAxeMode} mode`
+      `'${attackName}' is not a valid Switch Axe attack for '${switchAxeMode}' mode`
     );
   }
   return result as WeaponTypes.Attack<SwitchAxeTypes.SwitchAxeAttack>;
@@ -99,7 +99,7 @@ function validateSwitchAxe(
     weapon.type !== WeaponClass.SWITCH_AXE ||
     (weapon as SwitchAxeTypes.SwitchAxe).phial === undefined
   ) {
-    throw new Error(`${weapon.name} is not a ${WeaponClass.SWITCH_AXE}`);
+    throw new Error(`'${weapon.name}' is not a '${WeaponClass.SWITCH_AXE}'`);
   }
 }
 

--- a/src/damage/util/sword-and-shield-damage.ts
+++ b/src/damage/util/sword-and-shield-damage.ts
@@ -34,7 +34,7 @@ function getSwordAndShieldAttack(
   ).attackModes.find(atkGroup => atkGroup.name === swordAndShieldMode);
   if (!swordAndShieldAttacks) {
     throw new Error(
-      `${swordAndShieldMode} is not a valid sword and shield attack mode`
+      `'${swordAndShieldMode}' is not a valid sword and shield attack mode`
     );
   }
   const result = swordAndShieldAttacks.attacks.find(
@@ -42,7 +42,7 @@ function getSwordAndShieldAttack(
   );
   if (!result) {
     throw new Error(
-      `${attackName} is not a valid sword and shield attack for ${swordAndShieldMode} mode`
+      `'${attackName}' is not a valid sword and shield attack for '${swordAndShieldMode}' mode`
     );
   }
   return result as WeaponTypes.Attack<SwordAndShieldTypes.SwordAndShieldAttack>;
@@ -52,7 +52,9 @@ function validateSwordAndShield(
   weapon: WeaponTypes.Weapon
 ): asserts weapon is SwordAndShieldTypes.SwordAndShield {
   if (weapon.type !== WeaponClass.SWORD_AND_SHIELD) {
-    throw new Error(`${weapon.name} is not a ${WeaponClass.SWORD_AND_SHIELD}`);
+    throw new Error(
+      `'${weapon.name}' is not a '${WeaponClass.SWORD_AND_SHIELD}'`
+    );
   }
 }
 

--- a/src/damage/util/sword-and-shield-damage.ts
+++ b/src/damage/util/sword-and-shield-damage.ts
@@ -66,7 +66,8 @@ export function calculateSwordAndShieldDamage(
 ) {
   const { weaponId, attackName, sharpness } = weaponArgs;
   const { swordAndShieldMode } = weaponArgs.weaponMultipliers;
-  const { hitzoneValues, levelMultipliers } = monsterMultipliers;
+  const { hitzoneValues, statMultipliers: levelMultipliers } =
+    monsterMultipliers;
   const { rawArgs, elementArgs, weaponClassArgs } = damageBuffArgs;
 
   const swordAndShield = Weapons.getWeapon(

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,1 @@
+export type * from './types';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Tail-recursion type-helper to enumerate values
+ * @see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#tail-recursion-elimination-on-conditional-types
+ * @example
+ * type MyNumbers = Enumerate<3> // 0 | 1 | 2
+ */
+export type Enumerate<
+  N extends number,
+  Acc extends number[] = []
+> = Acc['length'] extends N
+  ? Acc[number]
+  : Enumerate<N, [...Acc, Acc['length']]>;
+
+/**
+ * Allows the definition of a range of numbers
+ *
+ * @param Min Inclusive minimum value
+ * @param Max Exclusive maximum value
+ */
+export type NumericRange<Min extends number, Max extends number> = Exclude<
+  Enumerate<Max>,
+  Enumerate<Min>
+>;

--- a/src/model/monster-levels/monster-level-data.ts
+++ b/src/model/monster-levels/monster-level-data.ts
@@ -2,52 +2,73 @@ import { deepFreeze } from '../../utils';
 import type { MonsterLevelRecord } from './types';
 
 /**
- * !This data is not 100% accurate.
+ * !Defense multipliers may not be 100% accurate for some levels
+ * This dataset was likely derived by examining the pre-defined quest files. Not all levels were accounted for.
+ * The dataset was expanded by manually checking the HP and stagger limits of missing level definitions.
  *
- * Health multipliers do not actually work this way. Rather, each level
- * should correspond to a singular health multiplier. There is an additional
- * property in the quest format that allows for a variable level range
- * for a monster in the quest.
- *
- * This dataset was likely derived by examining the pre-defined quest files.
- *
- * Defense and stagger multpliers DO appear to be accurate.
+ * - The lowest "real" low rank quest is level `23` (but it appears it can go down to `19`)
+ * - The lowest "real" high rank quest is level `44` (but it appears it can go down to `41`)
  */
 export const MonsterLevelData = deepFreeze<MonsterLevelRecord>({
-  0: { health: [1], defense: 1, stagger: 1 }, // DEFAULT
-  3: { health: [0.35, 0.38, 0.4, 0.43, 0.45], defense: 1, stagger: 1 },
-  5: { health: [0.4, 0.43, 0.45, 0.48, 0.5], defense: 1, stagger: 1 },
-  7: { health: [0.45, 0.48, 0.5, 0.55, 0.6], defense: 1, stagger: 1 },
-  9: { health: [0.5, 0.55, 0.6, 0.65, 0.7], defense: 1, stagger: 1 },
-  11: { health: [0.6, 0.65, 0.7, 0.75, 0.8], defense: 1, stagger: 1 },
-  13: { health: [0.7, 0.75, 0.8, 0.85, 0.9], defense: 1, stagger: 1 },
-  16: { health: [0.7], defense: 0.9, stagger: 1 },
-  17: { health: [0.75], defense: 0.9, stagger: 1 },
-  18: { health: [0.9], defense: 0.9, stagger: 1 },
-  23: { health: [1.05, 1.08, 1.1, 1.12, 1.15], defense: 0.95, stagger: 1.5 },
-  25: { health: [1.1, 1.12, 1.15, 1.17, 1.2], defense: 0.95, stagger: 1.5 },
-  26: { health: [0.64], defense: 0.95, stagger: 1.5 },
-  27: { health: [1.15, 1.17, 1.2, 1.22, 1.25], defense: 0.95, stagger: 1.5 },
-  29: { health: [1.2, 1.22, 1.25, 1.27, 1.3], defense: 0.95, stagger: 1.5 },
-  30: { health: [1.27], defense: 0.95, stagger: 1.5 },
-  31: { health: [1.3], defense: 0.95, stagger: 1.6 },
-  32: { health: [1.3, 1.32, 1.35], defense: 0.95, stagger: 1.6 },
-  36: { health: [0.8], defense: 0.95, stagger: 1.5 },
-  37: { health: [0.95], defense: 0.95, stagger: 1.5 },
-  38: { health: [0.8], defense: 0.95, stagger: 1.5 },
-  39: { health: [0.7], defense: 0.95, stagger: 1.5 },
-  40: { health: [0.8], defense: 0.95, stagger: 1.5 },
-  44: { health: [1.48, 1.52, 1.56], defense: 0.8, stagger: 2.1 },
-  45: { health: [1.48, 1.52, 1.56, 1.59, 1.63], defense: 0.8, stagger: 2.1 },
-  48: { health: [1.63, 1.67, 1.71], defense: 0.75, stagger: 2.2 },
-  50: { health: [1.71, 1.75, 1.79], defense: 0.75, stagger: 2.2 },
-  52: { health: [1], defense: 0.75, stagger: 2.2 },
-  53: { health: [1.6], defense: 0.75, stagger: 2.2 },
-  54: { health: [1.3], defense: 0.75, stagger: 2.1 },
-  55: { health: [1.1], defense: 0.75, stagger: 1.9 },
-  56: { health: [0.9], defense: 0.75, stagger: 1.9 },
-  57: { health: [1.9], defense: 0.75, stagger: 2.2 },
-  58: { health: [1.1], defense: 0.75, stagger: 2.2 },
-  59: { health: [1.3], defense: 0.75, stagger: 2.2 },
-  60: { health: [1.5], defense: 0.75, stagger: 2.2 }
+  0: { health: 1, defense: 1, stagger: 1 }, // DEFAULT
+  1: { health: 0.35, defense: 1, stagger: 1 },
+  2: { health: 0.38, defense: 1, stagger: 1 },
+  3: { health: 0.4, defense: 1, stagger: 1 },
+  4: { health: 0.43, defense: 1, stagger: 1 },
+  5: { health: 0.45, defense: 1, stagger: 1 },
+  6: { health: 0.48, defense: 1, stagger: 1 },
+  7: { health: 0.5, defense: 1, stagger: 1 },
+  8: { health: 0.55, defense: 1, stagger: 1 },
+  9: { health: 0.6, defense: 1, stagger: 1 },
+  10: { health: 0.65, defense: 1, stagger: 1 },
+  11: { health: 0.7, defense: 1, stagger: 1 },
+  12: { health: 0.75, defense: 1, stagger: 1 },
+  13: { health: 0.8, defense: 1, stagger: 1 },
+  14: { health: 0.85, defense: 1, stagger: 1 },
+  15: { health: 0.9, defense: 1, stagger: 1 },
+  16: { health: 0.7, defense: 0.9, stagger: 1 },
+  17: { health: 0.75, defense: 0.9, stagger: 1 },
+  18: { health: 0.9, defense: 0.9, stagger: 1 },
+  19: { health: 1.4, defense: 0.9, stagger: 1.5 },
+  20: { health: 1.5, defense: 0.9, stagger: 1.5 },
+  21: { health: 1.05, defense: 0.9, stagger: 1.5 },
+  22: { health: 1.08, defense: 0.9, stagger: 1.5 },
+  23: { health: 1.1, defense: 0.95, stagger: 1.5 }, //! Begin online low rank
+  24: { health: 1.12, defense: 0.95, stagger: 1.5 },
+  25: { health: 1.15, defense: 0.95, stagger: 1.5 },
+  26: { health: 1.17, defense: 0.95, stagger: 1.5 },
+  27: { health: 1.2, defense: 0.95, stagger: 1.5 },
+  28: { health: 1.22, defense: 0.95, stagger: 1.5 },
+  29: { health: 1.25, defense: 0.95, stagger: 1.5 },
+  30: { health: 1.27, defense: 0.95, stagger: 1.5 },
+  31: { health: 1.3, defense: 0.95, stagger: 1.6 },
+  32: { health: 1.32, defense: 0.95, stagger: 1.6 },
+  33: { health: 1.35, defense: 0.95, stagger: 1.6 },
+  34: { health: 0.75, defense: 0.95, stagger: 1.6 },
+  35: { health: 1.3, defense: 0.95, stagger: 1.6 },
+  36: { health: 0.8, defense: 0.95, stagger: 1.5 },
+  37: { health: 0.95, defense: 0.95, stagger: 1.5 },
+  38: { health: 0.8, defense: 0.95, stagger: 1.5 },
+  39: { health: 0.7, defense: 0.95, stagger: 1.5 },
+  40: { health: 0.8, defense: 0.95, stagger: 1.5 },
+  41: { health: 1.4, defense: 0.8, stagger: 2.09 },
+  42: { health: 1.43, defense: 0.8, stagger: 2.09 },
+  43: { health: 1.48, defense: 0.8, stagger: 2.1 },
+  44: { health: 1.52, defense: 0.8, stagger: 2.1 }, //! Begin online high rank
+  45: { health: 1.56, defense: 0.8, stagger: 2.1 },
+  46: { health: 1.59, defense: 0.8, stagger: 2.1 },
+  47: { health: 1.63, defense: 0.8, stagger: 2.1 },
+  48: { health: 1.67, defense: 0.75, stagger: 2.2 },
+  49: { health: 1.71, defense: 0.75, stagger: 2.2 },
+  50: { health: 1.75, defense: 0.75, stagger: 2.2 },
+  51: { health: 1.79, defense: 0.75, stagger: 2.2 },
+  52: { health: 1, defense: 0.75, stagger: 2.2 },
+  53: { health: 1.6, defense: 0.75, stagger: 2.2 },
+  54: { health: 1.3, defense: 0.75, stagger: 2.1 },
+  55: { health: 1.1, defense: 0.75, stagger: 1.9 },
+  56: { health: 0.9, defense: 0.75, stagger: 1.9 },
+  57: { health: 1.9, defense: 0.75, stagger: 2.2 },
+  58: { health: 1.1, defense: 0.75, stagger: 2.2 },
+  59: { health: 1.3, defense: 0.75, stagger: 2.2 },
+  60: { health: 1.5, defense: 0.75, stagger: 2.2 }
 });

--- a/src/model/monster-levels/monster-level-data.ts
+++ b/src/model/monster-levels/monster-level-data.ts
@@ -1,5 +1,5 @@
 import { deepFreeze } from '../../utils';
-import type { MonsterLevelRecord } from './types';
+import type { MonsterLevel, MonsterStatMultipliers } from './types';
 
 /**
  * !Defense multipliers may not be 100% accurate for some levels
@@ -9,7 +9,9 @@ import type { MonsterLevelRecord } from './types';
  * - The lowest "real" low rank quest is level `23` (but it appears it can go down to `19`)
  * - The lowest "real" high rank quest is level `44` (but it appears it can go down to `41`)
  */
-export const MonsterLevelData = deepFreeze<MonsterLevelRecord>({
+export const MonsterLevelData = deepFreeze<
+  Record<MonsterLevel, MonsterStatMultipliers>
+>({
   0: { health: 1, defense: 1, stagger: 1 }, // DEFAULT
   1: { health: 0.35, defense: 1, stagger: 1 },
   2: { health: 0.38, defense: 1, stagger: 1 },

--- a/src/model/monster-levels/monster-level-util.ts
+++ b/src/model/monster-levels/monster-level-util.ts
@@ -1,83 +1,93 @@
 import { getMonster, MonsterType, type MonsterTypes } from '../monsters';
+import type { Monster } from '../monsters/types';
 import { BossLevelModifiers, getQuestById, type QuestTypes } from '../quests';
 import { MonsterLevelData } from './monster-level-data';
 import type { MonsterLevel, MonsterStatMultipliers } from './types';
 
-function getStatMultipliers(level: number) {
-  const multipliers: MonsterStatMultipliers | undefined =
-    MonsterLevelData[level as MonsterLevel];
+/** Ensures a number is within valid range for a {@link MonsterLevel} */
+export function isValidMonsterLevel(
+  maybeLevel: number
+): asserts maybeLevel is MonsterLevel {
+  if (maybeLevel < 0 || maybeLevel > 60) {
+    throw new Error(`'${maybeLevel}' must be within 0 and 60`);
+  }
+}
 
-  if (!multipliers) throw new Error(`No multipliers found for level ${level}`);
+/**
+ * @returns List of monster levels based on an original level and a levelModifier
+ */
+export function getMonsterLevelRange(
+  monsterLevel: MonsterLevel,
+  levelModifier: BossLevelModifiers
+): MonsterLevel[] {
+  const result: number[] = [];
+
+  switch (levelModifier) {
+    case BossLevelModifiers.Fixed:
+      result.push(monsterLevel);
+      break;
+    case BossLevelModifiers.PlusOne:
+      result.push(monsterLevel - 1, monsterLevel, monsterLevel + 1);
+      break;
+    case BossLevelModifiers.PlusTwo:
+      result.push(
+        monsterLevel - 2,
+        monsterLevel - 1,
+        monsterLevel,
+        monsterLevel + 1,
+        monsterLevel + 2
+      );
+      break;
+    default:
+      throw new Error(`Unknown levelModifier '${levelModifier}'`);
+  }
+
+  result.forEach(r => isValidMonsterLevel(r));
+  return result as MonsterLevel[];
+}
+
+/**
+ *
+ * @param monsterLevel
+ * @returns
+ */
+export function getMonsterStatMultipliers(
+  monsterName: Monster['name'],
+  monsterLevel: MonsterLevel
+): MonsterStatMultipliers {
+  const multipliers: MonsterStatMultipliers | undefined =
+    MonsterLevelData[monsterLevel];
+
+  if (!multipliers)
+    throw new Error(`No multipliers found for level '${monsterLevel}'`);
+
+  if (getMonster(monsterName).type === MonsterType.EldDrg) {
+    // Elder Dragons always have a stagger multiplier of 1
+    return {
+      ...multipliers,
+      stagger: 1
+    };
+  }
 
   return multipliers;
 }
 
 /**
- * @returns Multipliers corresponding to a given level
+ * @returns MonsterLevel for a given monster ID in a quest ID
+ * @throws Error if monster is not present in quest
  */
-export function getMonsterStatMultipliers(
-  monsterName: MonsterTypes.MonsterName,
-  level: MonsterLevel,
-  levelModifier: BossLevelModifiers = BossLevelModifiers.Fixed
-): MonsterStatMultipliers[] {
-  const multipliersResult: MonsterStatMultipliers[] = [];
-
-  // levelModifer will dictate if we need to return a range of possible multipliers
-  switch (levelModifier) {
-    case BossLevelModifiers.Fixed:
-      multipliersResult.push(getStatMultipliers(level));
-      break;
-    case BossLevelModifiers.PlusOne:
-      multipliersResult.push(
-        getStatMultipliers(level - 1),
-        getStatMultipliers(level),
-        getStatMultipliers(level + 1)
-      );
-      break;
-    case BossLevelModifiers.PlusTwo:
-      multipliersResult.push(
-        getStatMultipliers(level - 2),
-        getStatMultipliers(level - 1),
-        getStatMultipliers(level),
-        getStatMultipliers(level + 1),
-        getStatMultipliers(level + 2)
-      );
-      break;
-    default:
-      throw new Error(`Unknown levelModifier ${levelModifier}`);
-  }
-
-  const monster = getMonster(monsterName);
-
-  if (monster.type !== MonsterType.EldDrg) return multipliersResult;
-
-  // Elder dragons always have a stagger multiplier of 1
-  return multipliersResult.map(result => ({
-    ...result,
-    stagger: 1
-  }));
-}
-
-/**
- * @returns MonsterStatMultiplier for a given monster ID in a quest ID.
- * @throw Error if monster is not present in quest
- */
-export function getMonsterMultipliersForQuest(
+export function getMonsterLevelsForQuest(
   monsterName: MonsterTypes.MonsterName,
   questId: QuestTypes.Quest['id']
-): MonsterStatMultipliers[] {
+) {
   const quest = getQuestById(questId);
   const monster = getMonster(monsterName);
 
   const bossInfo = quest.bosses.find(boss => boss.monsterId === monster.id);
   if (!bossInfo)
     throw new Error(
-      `Quest ID ${questId} does not include monster ID ${monster.id}`
+      `Quest ID '${questId}' does not include monster ID '${monster.id}'`
     );
 
-  return getMonsterStatMultipliers(
-    monsterName,
-    bossInfo.level,
-    bossInfo.levelModifier
-  );
+  return getMonsterLevelRange(bossInfo.level, bossInfo.levelModifier);
 }

--- a/src/model/monster-levels/types.ts
+++ b/src/model/monster-levels/types.ts
@@ -1,6 +1,7 @@
 import type { NumericRange } from '../../lib';
+
 /**
- * Contains multipliers against different base monster stats.
+ * Contains multipliers for monster health, defense, and stagger limit.
  */
 export interface MonsterStatMultipliers {
   readonly health: number;

--- a/src/model/monster-levels/types.ts
+++ b/src/model/monster-levels/types.ts
@@ -1,57 +1,19 @@
+import type { NumericRange } from '../../lib';
 /**
  * Contains multipliers against different base monster stats.
  */
-export interface MonsterLevelMultipliers {
-  readonly health: number[];
+export interface MonsterStatMultipliers {
+  readonly health: number;
   readonly defense: number;
   readonly stagger: number;
 }
 
 /**
- * All known monster levels. Potentially incomplete.
- *
- * A monster level maps to an object containing scalers for monster health,
- * defense, and flinch values.
+ * All known monster levels, ranging from 0 to 60.
  */
-export type MonsterLevel =
-  | 0 // DEFAULT
-  | 3
-  | 5
-  | 7
-  | 9
-  | 11
-  | 13
-  | 16
-  | 17
-  | 18
-  | 23
-  | 25
-  | 26
-  | 27
-  | 29
-  | 30
-  | 31
-  | 32
-  | 36
-  | 37
-  | 38
-  | 39
-  | 40
-  | 44
-  | 45
-  | 48
-  | 50
-  | 52
-  | 53
-  | 54
-  | 55
-  | 56
-  | 57
-  | 58
-  | 59
-  | 60;
+export type MonsterLevel = NumericRange<0, 61>;
 
 /**
  * Collection of monster levels paired with stat multipliers
  */
-export type MonsterLevelRecord = Record<MonsterLevel, MonsterLevelMultipliers>;
+export type MonsterLevelRecord = Record<MonsterLevel, MonsterStatMultipliers>;

--- a/src/model/monster-levels/types.ts
+++ b/src/model/monster-levels/types.ts
@@ -13,8 +13,3 @@ export interface MonsterStatMultipliers {
  * All known monster levels, ranging from 0 to 60.
  */
 export type MonsterLevel = NumericRange<0, 61>;
-
-/**
- * Collection of monster levels paired with stat multipliers
- */
-export type MonsterLevelRecord = Record<MonsterLevel, MonsterStatMultipliers>;

--- a/src/model/monsters/monsters-util.ts
+++ b/src/model/monsters/monsters-util.ts
@@ -12,7 +12,7 @@ import { SmallMonsterData, LargeMonsterData } from '.';
 export function getSmallMonster(name: SmallMonsterName): Monster {
   const smMonster = SmallMonsterData.find(smMon => smMon.name === name);
 
-  if (!smMonster) throw new Error(`Could not find small monster ${name}`);
+  if (!smMonster) throw new Error(`Could not find small monster '${name}'`);
   return smMonster;
 }
 
@@ -22,7 +22,7 @@ export function getSmallMonster(name: SmallMonsterName): Monster {
 export function getLargeMonster(name: LargeMonsterName): LargeMonster {
   const lgMonster = LargeMonsterData.find(lgMon => lgMon.name === name);
 
-  if (!lgMonster) throw new Error(`Could not find large monster ${name}`);
+  if (!lgMonster) throw new Error(`Could not find large monster '${name}'`);
   return lgMonster;
 }
 
@@ -34,6 +34,13 @@ export function getMonster(name: SmallMonsterName | LargeMonsterName) {
     mon => mon.name === name
   );
 
-  if (!monster) throw new Error(`Could not find monster ${name}`);
+  if (!monster) throw new Error(`Could not find monster '${name}'`);
   return monster;
+}
+
+/**
+ * Type-guard for a large monster
+ */
+export function isLargeMonster(monster: Monster): monster is LargeMonster {
+  return (monster as LargeMonster).hp !== undefined;
 }

--- a/src/model/monsters/types.ts
+++ b/src/model/monsters/types.ts
@@ -179,7 +179,7 @@ export interface Monster {
   readonly shiny?: ShinyDrop;
   /** If undefined this monster should have a 'variant' property */
   readonly carves?: CarveZone[];
-  /** Optional support for varying shines or carves */
+  /** Optional support for varying shinies or carves */
   readonly variants?: Variant[];
 }
 

--- a/src/model/quests/city-quest-data.ts
+++ b/src/model/quests/city-quest-data.ts
@@ -17,7 +17,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 141: 14 },
         contract: 0,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 1000,
         ko: 340,
@@ -48,7 +48,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 398: 15 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 1200,
         ko: 400,
@@ -79,7 +79,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 310: 5 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 1000,
         ko: 340,
@@ -109,7 +109,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 11: 8 },
         contract: 150,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 1600,
         ko: 540,
@@ -139,7 +139,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 17: 1 },
         contract: 200,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 2000,
         ko: 670,
@@ -150,8 +150,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 23,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -179,7 +179,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 21: 1 },
         contract: 350,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 3600,
         ko: 1200,
@@ -190,8 +190,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 23,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -219,7 +219,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 27: 1 },
         contract: 400,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 5500,
         ko: 1840,
@@ -230,8 +230,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 23,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -256,7 +256,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 364: 14 },
         contract: 100,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 1400,
         ko: 470,
@@ -286,7 +286,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 397: 10 },
         contract: 150,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 1500,
         ko: 500,
@@ -316,7 +316,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 17: 1 },
         contract: 200,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 3000,
         ko: 1000,
@@ -327,8 +327,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 23,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -356,7 +356,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 21: 1 },
         contract: 350,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 5100,
         ko: 1700,
@@ -367,8 +367,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 23,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -396,7 +396,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 203: 6 },
         contract: 350,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 3600,
         ko: 1200,
@@ -427,7 +427,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 13: 10 },
         contract: 150,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 1800,
         ko: 600,
@@ -455,7 +455,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 27: 1 },
         contract: 400,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 4000,
         ko: 1340,
@@ -466,8 +466,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 23,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -497,7 +497,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 20,
         ko: 7,
@@ -524,7 +524,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 5: 15 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 1200,
         ko: 400,
@@ -555,7 +555,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 136: 3 },
         contract: 600,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 6000,
         ko: 2000,
@@ -586,7 +586,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1 },
         contract: 500,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 7200,
         ko: 2400,
@@ -597,8 +597,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 27,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -626,7 +626,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 20,
         ko: 7,
@@ -653,7 +653,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 16: 13 },
         contract: 1500,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 1800,
         ko: 600,
@@ -681,7 +681,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 363: 3 },
         contract: 400,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 4000,
         ko: 1340,
@@ -712,7 +712,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 19: 1 },
         contract: 500,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 7200,
         ko: 2400,
@@ -723,8 +723,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 25,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -750,7 +750,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 4: 20 },
         contract: 150,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 1600,
         ko: 540,
@@ -780,7 +780,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 28: 1 },
         contract: 550,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 5600,
         ko: 1870,
@@ -791,8 +791,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 27,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -817,7 +817,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 28: 1 },
         contract: 550,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 7600,
         ko: 2540,
@@ -828,8 +828,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 27,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -857,7 +857,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1 },
         contract: 500,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 5200,
         ko: 1740,
@@ -868,8 +868,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 27,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -897,7 +897,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 395: 13 },
         contract: 150,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 1800,
         ko: 600,
@@ -928,7 +928,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 18: 1 },
         contract: 250,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 2800,
         ko: 940,
@@ -939,8 +939,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 25,
             size: 100,
-            min: 1,
-            max: 5
+            levelModifier: 1,
+            sizeModifier: 5
           }
         ],
         secondaryRewards: [
@@ -967,7 +967,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 18: 1 },
         contract: 250,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 3800,
         ko: 1270,
@@ -978,8 +978,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 25,
             size: 100,
-            min: 1,
-            max: 5
+            levelModifier: 1,
+            sizeModifier: 5
           }
         ],
         secondaryRewards: [
@@ -1006,7 +1006,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 19: 1 },
         contract: 500,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 5200,
         ko: 1740,
@@ -1017,8 +1017,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 25,
             size: 100,
-            min: 0,
-            max: 3
+            levelModifier: 0,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1048,7 +1048,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 20,
         ko: 7,
@@ -1075,7 +1075,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 20,
         ko: 7,
@@ -1102,7 +1102,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 23: 1 },
         contract: 800,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 8000,
         ko: 2670,
@@ -1113,8 +1113,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 29,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1143,7 +1143,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 24: 1 },
         contract: 850,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 8800,
         ko: 2940,
@@ -1154,8 +1154,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 29,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1182,7 +1182,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 24: 1 },
         contract: 850,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 12800,
         ko: 4270,
@@ -1193,8 +1193,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 29,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1220,7 +1220,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 29: 1 },
         contract: 750,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 10600,
         ko: 3540,
@@ -1231,8 +1231,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 29,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1258,7 +1258,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 25: 1 },
         contract: 600,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 6000,
         ko: 2000,
@@ -1269,8 +1269,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 27,
             size: 100,
-            min: 1,
-            max: 4
+            levelModifier: 1,
+            sizeModifier: 4
           }
         ],
         secondaryRewards: [
@@ -1298,7 +1298,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 26: 1 },
         contract: 800,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 8000,
         ko: 2670,
@@ -1309,8 +1309,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 29,
             size: 100,
-            min: 1,
-            max: 4
+            levelModifier: 1,
+            sizeModifier: 4
           }
         ],
         secondaryRewards: [
@@ -1341,7 +1341,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 26: 1 },
         contract: 800,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 11100,
         ko: 3700,
@@ -1352,8 +1352,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 29,
             size: 100,
-            min: 1,
-            max: 4
+            levelModifier: 1,
+            sizeModifier: 4
           }
         ],
         secondaryRewards: [
@@ -1379,7 +1379,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 14: 15 },
         contract: 150,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 1900,
         ko: 640,
@@ -1410,7 +1410,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 350: 3 },
         contract: 800,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 8000,
         ko: 2670,
@@ -1441,7 +1441,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 20: 1 },
         contract: 850,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 8800,
         ko: 2940,
@@ -1452,8 +1452,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 29,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1480,7 +1480,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 20: 1 },
         contract: 850,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 12800,
         ko: 4270,
@@ -1491,8 +1491,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 29,
             size: 100,
-            min: 1,
-            max: 3
+            levelModifier: 1,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1518,7 +1518,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1, 23: 1 },
         contract: 1550,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 15700,
         ko: 5240,
@@ -1529,16 +1529,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 40,
             size: 100,
-            min: 0,
-            max: 3
+            levelModifier: 0,
+            sizeModifier: 3
           },
           {
             monsterId: 23,
             startingArea: 1,
             level: 40,
             size: 100,
-            min: 0,
-            max: 3
+            levelModifier: 0,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1562,7 +1562,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 25: 1 },
         contract: 700,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 10200,
         ko: 3400,
@@ -1573,8 +1573,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 32,
             size: 100,
-            min: 2,
-            max: 4
+            levelModifier: 2,
+            sizeModifier: 4
           }
         ],
         secondaryRewards: [
@@ -1601,7 +1601,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 23: 1 },
         contract: 850,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 11600,
         ko: 3870,
@@ -1612,8 +1612,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 32,
             size: 100,
-            min: 2,
-            max: 3
+            levelModifier: 2,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1640,7 +1640,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 30: 1 },
         contract: 1100,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 11000,
         ko: 3670,
@@ -1651,8 +1651,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 32,
             size: 100,
-            min: 2,
-            max: 3
+            levelModifier: 2,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1681,7 +1681,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 29: 1 },
         contract: 750,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 7600,
         ko: 2540,
@@ -1692,8 +1692,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 27,
             size: 100,
-            min: 0,
-            max: 3
+            levelModifier: 0,
+            sizeModifier: 3
           }
         ],
         secondaryRewards: [
@@ -1722,7 +1722,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 33: 1 },
         contract: 1500,
         time: 30,
-        location: MapLocation.GREAT_DESERT,
+        location: MapLocation.GreatDesert,
         randomspawn: false,
         reward: 15000,
         ko: 5000,
@@ -1733,8 +1733,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 30,
             size: 100,
-            min: 0,
-            max: 0
+            levelModifier: 0,
+            sizeModifier: 0
           }
         ],
         secondaryRewards: [
@@ -1756,7 +1756,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 33: 60 },
         contract: 750,
         time: 30,
-        location: MapLocation.GREAT_DESERT,
+        location: MapLocation.GreatDesert,
         randomspawn: false,
         reward: 7500,
         ko: 2500,
@@ -1767,8 +1767,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 27,
             size: 100,
-            min: 0,
-            max: 0
+            levelModifier: 0,
+            sizeModifier: 0
           }
         ],
         secondaryRewards: [
@@ -1795,7 +1795,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 20,
         ko: 7,
@@ -1822,7 +1822,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 17: 1 },
         contract: 300,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 3000,
         ko: 1000,
@@ -1833,8 +1833,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -1861,7 +1861,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 21: 1 },
         contract: 500,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 5400,
         ko: 1800,
@@ -1872,8 +1872,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -1902,7 +1902,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1 },
         contract: 750,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 7800,
         ko: 2600,
@@ -1913,8 +1913,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -1941,7 +1941,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 20,
         ko: 7,
@@ -1968,7 +1968,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 397: 10 },
         contract: 200,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: true,
         reward: 2400,
         ko: 800,
@@ -1999,7 +1999,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 17: 2 },
         contract: 600,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: true,
         reward: 6000,
         ko: 2000,
@@ -2010,16 +2010,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           },
           {
             monsterId: 17,
             startingArea: 1,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2043,7 +2043,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 21: 1 },
         contract: 500,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: true,
         reward: 7900,
         ko: 2640,
@@ -2054,8 +2054,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2083,7 +2083,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1 },
         contract: 750,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: true,
         reward: 10800,
         ko: 3600,
@@ -2094,8 +2094,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2125,7 +2125,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 19: 1 },
         contract: 750,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: true,
         reward: 7800,
         ko: 2600,
@@ -2136,8 +2136,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2166,7 +2166,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 4: 20 },
         contract: 200,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: true,
         reward: 2400,
         ko: 800,
@@ -2198,7 +2198,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 13: 10 },
         contract: 250,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: true,
         reward: 2700,
         ko: 900,
@@ -2229,7 +2229,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 203: 6 },
         contract: 400,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: true,
         reward: 4200,
         ko: 1400,
@@ -2260,7 +2260,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 27: 1 },
         contract: 600,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: true,
         reward: 8500,
         ko: 2840,
@@ -2271,8 +2271,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2299,7 +2299,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 28: 1 },
         contract: 800,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: true,
         reward: 8400,
         ko: 2800,
@@ -2310,8 +2310,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 10
+            levelModifier: 1,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2337,7 +2337,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 27: 2 },
         contract: 1200,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 12000,
         ko: 4000,
@@ -2348,16 +2348,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 44,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           },
           {
             monsterId: 27,
             startingArea: 1,
             level: 44,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2382,7 +2382,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 19: 1 },
         contract: 900,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: true,
         reward: 9400,
         ko: 3140,
@@ -2393,8 +2393,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2424,7 +2424,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 28: 1 },
         contract: 1000,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: true,
         reward: 10000,
         ko: 3340,
@@ -2435,8 +2435,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2462,7 +2462,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 11: 25 },
         contract: 600,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 6000,
         ko: 2000,
@@ -2492,7 +2492,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 33: 1 },
         contract: 3600,
         time: 30,
-        location: MapLocation.GREAT_DESERT,
+        location: MapLocation.GreatDesert,
         randomspawn: false,
         reward: 36000,
         ko: 12000,
@@ -2503,8 +2503,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 52,
             size: 100,
-            min: 0,
-            max: 0
+            levelModifier: 0,
+            sizeModifier: 0
           }
         ],
         secondaryRewards: [
@@ -2531,7 +2531,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 23: 1 },
         contract: 1200,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 16000,
         ko: 5340,
@@ -2542,8 +2542,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2571,7 +2571,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 24: 1 },
         contract: 1300,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: true,
         reward: 13200,
         ko: 4400,
@@ -2582,8 +2582,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2611,7 +2611,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 20,
         ko: 7,
@@ -2639,7 +2639,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 29: 1 },
         contract: 1100,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: true,
         reward: 14900,
         ko: 4970,
@@ -2650,8 +2650,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2679,7 +2679,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 20,
         ko: 7,
@@ -2707,7 +2707,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 18: 1 },
         contract: 400,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: true,
         reward: 4200,
         ko: 1400,
@@ -2718,8 +2718,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 45,
             size: 100,
-            min: 1,
-            max: 12
+            levelModifier: 1,
+            sizeModifier: 12
           }
         ],
         secondaryRewards: [
@@ -2747,7 +2747,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 25: 1 },
         contract: 900,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: true,
         reward: 9000,
         ko: 3000,
@@ -2758,8 +2758,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 11
+            levelModifier: 2,
+            sizeModifier: 11
           }
         ],
         secondaryRewards: [
@@ -2789,7 +2789,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 25: 1 },
         contract: 900,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: true,
         reward: 12500,
         ko: 4170,
@@ -2800,8 +2800,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 11
+            levelModifier: 2,
+            sizeModifier: 11
           }
         ],
         secondaryRewards: [
@@ -2829,7 +2829,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 26: 1 },
         contract: 1200,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: true,
         reward: 12000,
         ko: 4000,
@@ -2840,8 +2840,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 11
+            levelModifier: 2,
+            sizeModifier: 11
           }
         ],
         secondaryRewards: [
@@ -2871,7 +2871,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 14: 20 },
         contract: 250,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: true,
         reward: 2800,
         ko: 940,
@@ -2903,7 +2903,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 23: 1 },
         contract: 1200,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: true,
         reward: 12000,
         ko: 4000,
@@ -2914,8 +2914,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2944,7 +2944,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 20: 1 },
         contract: 1300,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: true,
         reward: 13200,
         ko: 4400,
@@ -2955,8 +2955,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -2985,7 +2985,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 30: 1 },
         contract: 1350,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: true,
         reward: 13800,
         ko: 4600,
@@ -2996,8 +2996,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3027,7 +3027,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 30: 1 },
         contract: 1350,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: true,
         reward: 17800,
         ko: 5940,
@@ -3038,8 +3038,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 48,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3067,7 +3067,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 23: 1 },
         contract: 1400,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 14000,
         ko: 4670,
@@ -3078,8 +3078,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 50,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3108,7 +3108,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 29: 1 },
         contract: 1300,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 13150,
         ko: 4390,
@@ -3119,8 +3119,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 50,
             size: 100,
-            min: 2,
-            max: 10
+            levelModifier: 2,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3149,7 +3149,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 26: 1 },
         contract: 1400,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: true,
         reward: 14000,
         ko: 4670,
@@ -3160,8 +3160,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 50,
             size: 100,
-            min: 2,
-            max: 11
+            levelModifier: 2,
+            sizeModifier: 11
           }
         ],
         secondaryRewards: [
@@ -3186,7 +3186,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 20: 2 },
         contract: 3000,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: true,
         reward: 30000,
         ko: 10000,
@@ -3197,16 +3197,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 1,
             level: 58,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           },
           {
             monsterId: 20,
             startingArea: 2,
             level: 58,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3231,7 +3231,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1, 23: 1 },
         contract: 1950,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 19800,
         ko: 6600,
@@ -3242,16 +3242,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 54,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           },
           {
             monsterId: 23,
             startingArea: 1,
             level: 54,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3278,7 +3278,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 32: 1 },
         contract: 1800,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: true,
         reward: 18000,
         ko: 6000,
@@ -3289,8 +3289,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 52,
             size: 100,
-            min: 0,
-            max: 13
+            levelModifier: 0,
+            sizeModifier: 13
           }
         ],
         secondaryRewards: [
@@ -3314,7 +3314,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 32: 1 },
         contract: 1800,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: true,
         reward: 18000,
         ko: 6000,
@@ -3325,8 +3325,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 52,
             size: 100,
-            min: 0,
-            max: 13
+            levelModifier: 0,
+            sizeModifier: 13
           }
         ],
         secondaryRewards: [
@@ -3351,7 +3351,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 32: 1 },
         contract: 1800,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: true,
         reward: 18000,
         ko: 6000,
@@ -3362,8 +3362,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 52,
             size: 100,
-            min: 0,
-            max: 13
+            levelModifier: 0,
+            sizeModifier: 13
           }
         ],
         secondaryRewards: [
@@ -3388,7 +3388,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1, 23: 1 },
         contract: 2200,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: true,
         reward: 22000,
         ko: 7340,
@@ -3399,16 +3399,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 53,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           },
           {
             monsterId: 23,
             startingArea: 1,
             level: 53,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3434,7 +3434,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 24: 2 },
         contract: 2600,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: true,
         reward: 26000,
         ko: 8670,
@@ -3445,16 +3445,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 53,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           },
           {
             monsterId: 24,
             startingArea: 1,
             level: 53,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3479,7 +3479,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 29: 1, 28: 1 },
         contract: 1950,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: true,
         reward: 19800,
         ko: 6600,
@@ -3490,16 +3490,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 1,
             level: 53,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           },
           {
             monsterId: 28,
             startingArea: 1,
             level: 53,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3525,7 +3525,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 26: 2 },
         contract: 2400,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: true,
         reward: 24000,
         ko: 8000,
@@ -3536,16 +3536,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 1,
             level: 53,
             size: 100,
-            min: 0,
-            max: 11
+            levelModifier: 0,
+            sizeModifier: 11
           },
           {
             monsterId: 26,
             startingArea: 2,
             level: 53,
             size: 100,
-            min: 0,
-            max: 11
+            levelModifier: 0,
+            sizeModifier: 11
           }
         ],
         secondaryRewards: [
@@ -3571,7 +3571,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 30: 1, 20: 1 },
         contract: 2700,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: true,
         reward: 27000,
         ko: 9000,
@@ -3582,16 +3582,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 53,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           },
           {
             monsterId: 20,
             startingArea: 1,
             level: 53,
             size: 100,
-            min: 0,
-            max: 10
+            levelModifier: 0,
+            sizeModifier: 10
           }
         ],
         secondaryRewards: [
@@ -3617,7 +3617,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
         targets: { 34: 1 },
         contract: 3600,
         time: 50,
-        location: MapLocation.SACRED_LAND,
+        location: MapLocation.SacredLand,
         randomspawn: true,
         reward: 36000,
         ko: 12000,
@@ -3628,8 +3628,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 52,
             size: 100,
-            min: 0,
-            max: 0
+            levelModifier: 0,
+            sizeModifier: 0
           }
         ],
         secondaryRewards: [
@@ -3660,13 +3660,20 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 27: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.WATER_ARENA,
+      location: MapLocation.WaterArena,
       randomspawn: false,
       reward: 1000,
       ko: 200,
       hrp: 0,
       bosses: [
-        { monsterId: 27, startingArea: 0, level: 23, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 27,
+          startingArea: 0,
+          level: 23,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -3681,13 +3688,20 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 22: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 1000,
       ko: 200,
       hrp: 0,
       bosses: [
-        { monsterId: 22, startingArea: 0, level: 26, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 22,
+          startingArea: 0,
+          level: 26,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -3702,13 +3716,20 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 20: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 1500,
       ko: 220,
       hrp: 0,
       bosses: [
-        { monsterId: 20, startingArea: 0, level: 23, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 20,
+          startingArea: 0,
+          level: 23,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -3723,7 +3744,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 21: 1, 19: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 1000,
       ko: 200,
@@ -3734,10 +3755,17 @@ export const CityQuestData = deepFreeze<QuestMode>({
           startingArea: 0,
           level: 55,
           size: 100,
-          min: 0,
-          max: 0
+          levelModifier: 0,
+          sizeModifier: 0
         },
-        { monsterId: 19, startingArea: 0, level: 55, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 19,
+          startingArea: 0,
+          level: 55,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -3752,7 +3780,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 26: 1, 30: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 1500,
       ko: 220,
@@ -3763,10 +3791,17 @@ export const CityQuestData = deepFreeze<QuestMode>({
           startingArea: 0,
           level: 55,
           size: 100,
-          min: 0,
-          max: 0
+          levelModifier: 0,
+          sizeModifier: 0
         },
-        { monsterId: 30, startingArea: 0, level: 55, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 30,
+          startingArea: 0,
+          level: 55,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     }
@@ -3786,13 +3821,20 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 17: 4 },
       contract: 400,
       time: 50,
-      location: MapLocation.SANDY_PLAINS,
+      location: MapLocation.SandyPlains,
       randomspawn: false,
       reward: 4000,
       ko: 1340,
       hrp: 440,
       bosses: [
-        { monsterId: 17, startingArea: 0, level: 23, size: 100, min: 1, max: 3 }
+        {
+          monsterId: 17,
+          startingArea: 0,
+          level: 23,
+          size: 100,
+          levelModifier: 1,
+          sizeModifier: 3
+        }
       ],
       secondaryRewards: [
         { itemId: 406, count: 1, chance: 35 },
@@ -3814,7 +3856,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 24: 1, 20: 1 },
       contract: 1750,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 17600,
       ko: 5870,
@@ -3825,10 +3867,17 @@ export const CityQuestData = deepFreeze<QuestMode>({
           startingArea: 0,
           level: 40,
           size: 100,
-          min: 0,
-          max: 9
+          levelModifier: 0,
+          sizeModifier: 9
         },
-        { monsterId: 20, startingArea: 0, level: 40, size: 100, min: 0, max: 9 }
+        {
+          monsterId: 20,
+          startingArea: 0,
+          level: 40,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 9
+        }
       ],
       secondaryRewards: [
         { itemId: 558, count: 1, chance: 25 },
@@ -3852,7 +3901,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 28: 2 },
       contract: 1650,
       time: 50,
-      location: MapLocation.WATER_ARENA,
+      location: MapLocation.WaterArena,
       randomspawn: false,
       reward: 16800,
       ko: 5600,
@@ -3863,16 +3912,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
           startingArea: 0,
           level: 54,
           size: 100,
-          min: 0,
-          max: 10
+          levelModifier: 0,
+          sizeModifier: 10
         },
         {
           monsterId: 28,
           startingArea: 1,
           level: 54,
           size: 100,
-          min: 0,
-          max: 10
+          levelModifier: 0,
+          sizeModifier: 10
         }
       ],
       secondaryRewards: [
@@ -3896,7 +3945,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 30: 2 },
       contract: 2750,
       time: 50,
-      location: MapLocation.VOLCANO,
+      location: MapLocation.Volcano,
       randomspawn: true,
       reward: 13800,
       ko: 4600,
@@ -3907,8 +3956,8 @@ export const CityQuestData = deepFreeze<QuestMode>({
           startingArea: 0,
           level: 57,
           size: 100,
-          min: 0,
-          max: 10
+          levelModifier: 0,
+          sizeModifier: 10
         }
       ],
       secondaryRewards: [
@@ -3935,7 +3984,7 @@ export const CityQuestData = deepFreeze<QuestMode>({
       targets: { 26: 1, 23: 1 },
       contract: 4200,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 42000,
       ko: 14000,
@@ -3946,16 +3995,16 @@ export const CityQuestData = deepFreeze<QuestMode>({
           startingArea: 0,
           level: 60,
           size: 100,
-          min: 0,
-          max: 11
+          levelModifier: 0,
+          sizeModifier: 11
         },
         {
           monsterId: 23,
           startingArea: 0,
           level: 59,
           size: 100,
-          min: 0,
-          max: 10
+          levelModifier: 0,
+          sizeModifier: 10
         }
       ],
       secondaryRewards: [

--- a/src/model/quests/enum.ts
+++ b/src/model/quests/enum.ts
@@ -2,16 +2,16 @@
  * In-game maps
  */
 export enum MapLocation {
-  DESERTED_ISLAND = 'Deserted Island',
-  SANDY_PLAINS = 'Sandy Plains',
-  FLOODED_FOREST = 'Flooded Forest',
-  TUNDRA = 'Tundra',
-  VOLCANO = 'Volcano',
-  UNDERWATER_RUIN = 'Underwater Ruin',
-  GREAT_DESERT = 'Great Desert',
-  SACRED_LAND = 'Sacred Land',
-  LAND_ARENA = 'Land Arena',
-  WATER_ARENA = 'Water Arena'
+  DesertedIsland = 'Deserted Island',
+  SandyPlains = 'Sandy Plains',
+  FloodedForest = 'Flooded Forest',
+  Tundra = 'Tundra',
+  Volcano = 'Volcano',
+  UnderwaterRuin = 'Underwater Ruin',
+  GreatDesert = 'Great Desert',
+  SacredLand = 'Sacred Land',
+  LandArena = 'Land Arena',
+  WaterArena = 'Water Arena'
 }
 
 /** Possible ingame quest star levels */
@@ -27,4 +27,37 @@ export enum StarLevelEnum {
   FourStar = 4,
   FiveStar = 5,
   SixStar = 6
+}
+
+export enum BossLevelModifiers {
+  /**
+   * Monster level will be exactly equal to specified value
+   * @example
+   * { // BossInfo object
+   *   ...,
+   *   levelModifier: 0,
+   *   level: 23, // Monster level will always be 23
+   * }
+   */
+  Fixed = 0,
+  /**
+   * Monster level can be the specified value OR +/- 1.
+   * @example
+   * { // BossInfo object
+   *   ...,
+   *   levelModifier: 1,
+   *   level: 23, // Monster level can be 22, 23, or 24
+   * }
+   */
+  PlusOne = 1,
+  /**
+   * Monster level can be the specified value OR +/- 2.
+   * @example
+   * { // BossInfo object
+   *   ...,
+   *   levelModifier: 2,
+   *   level: 23, // Monster level can be 21, 22, 23, 24, or 25
+   * }
+   */
+  PlusTwo = 2
 }

--- a/src/model/quests/quests-util.ts
+++ b/src/model/quests/quests-util.ts
@@ -98,7 +98,7 @@ export function getQuestsWithLargeMonster(
       quests = villageQuests.concat(cityQuests);
       break;
     default:
-      throw new Error(`Invalid quest region ${region}`);
+      throw new Error(`Invalid quest region '${region}'`);
   }
 
   // Filter down quests that contain this large monster ID
@@ -119,7 +119,7 @@ export function getQuestByStarLevel(region: QuestRegion, starLevel: StarLevel) {
     case 'City':
       return Object.values(CityQuestData.starLevels[starLevel]);
     default:
-      throw new Error(`Invalid quest region ${region}`);
+      throw new Error(`Invalid quest region '${region}'`);
   }
 }
 
@@ -133,7 +133,7 @@ export function getArenaQuests(region: QuestRegion): SlayQuest[] {
     case 'City':
       return Object.values(CityQuestData.arena);
     default:
-      throw new Error(`Invalid quest region ${region}`);
+      throw new Error(`Invalid quest region '${region}'`);
   }
 }
 
@@ -147,7 +147,7 @@ export function getEventQuests(region: QuestRegion): Quest[] {
     case 'City':
       return Object.values(CityQuestData.events);
     default:
-      throw new Error(`Invalid quest region ${region}`);
+      throw new Error(`Invalid quest region '${region}'`);
   }
 }
 
@@ -171,7 +171,7 @@ export function getQuestById(questId: Quest['id']): Quest {
 
   quest = cityQuests.find(quest => quest.id === questId);
 
-  if (!quest) throw new Error(`Could not find quest with ID ${questId}`);
+  if (!quest) throw new Error(`Could not find quest with ID '${questId}'`);
 
   return quest;
 }

--- a/src/model/quests/types.ts
+++ b/src/model/quests/types.ts
@@ -1,7 +1,8 @@
 import type { MonsterLevelTypes } from '../monster-levels';
 import type { ItemTypes } from '../items';
 import type { MonsterTypes } from '../monsters';
-import { MapLocation, StarLevelEnum } from './enum';
+import { BossLevelModifiers, MapLocation, StarLevelEnum } from './enum';
+import type { NumericRange } from '../../lib';
 
 export type QuestRegion = 'Village' | 'City';
 export type QuestRank = 'Low' | 'High';
@@ -38,9 +39,9 @@ interface BossInfo {
   readonly level: MonsterLevelTypes.MonsterLevel;
   readonly size: number;
   /** controls random distribution of monster's level */
-  readonly min: number;
+  readonly levelModifier: BossLevelModifiers;
   /** controls random distribution of monster's size */
-  readonly max: number;
+  readonly sizeModifier: NumericRange<0, 14>;
 }
 
 /**

--- a/src/model/quests/village-quest-data.ts
+++ b/src/model/quests/village-quest-data.ts
@@ -17,7 +17,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 141: 5 },
         contract: 0,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 500,
         ko: 170,
@@ -48,7 +48,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 310: 2 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 600,
         ko: 200,
@@ -76,7 +76,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 203: 3 },
         contract: 150,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 1500,
         ko: 500,
@@ -106,7 +106,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 11: 5 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 800,
         ko: 270,
@@ -134,7 +134,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 397: 3 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 800,
         ko: 270,
@@ -145,8 +145,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 9,
             size: 100,
-            min: 0,
-            max: 0
+            levelModifier: 0,
+            sizeModifier: 0
           }
         ],
         secondaryRewards: [
@@ -170,7 +170,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 398: 8 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 600,
         ko: 200,
@@ -200,7 +200,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 5: 12 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 600,
         ko: 200,
@@ -231,7 +231,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 364: 4 },
         contract: 100,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 600,
         ko: 200,
@@ -259,7 +259,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 397: 3 },
         contract: 100,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 800,
         ko: 270,
@@ -287,7 +287,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 17: 1 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 1000,
         ko: 340,
@@ -298,8 +298,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 3,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -325,7 +325,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 17: 1 },
         contract: 100,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 2000,
         ko: 670,
@@ -336,8 +336,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 3,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -365,7 +365,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 13: 6 },
         contract: 100,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 700,
         ko: 240,
@@ -394,7 +394,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 16: 6 },
         contract: 100,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 900,
         ko: 300,
@@ -422,7 +422,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 363: 2 },
         contract: 100,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 1000,
         ko: 340,
@@ -453,7 +453,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 4: 12 },
         contract: 100,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 800,
         ko: 270,
@@ -483,7 +483,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 13: 7 },
         contract: 100,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 800,
         ko: 270,
@@ -511,7 +511,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 21: 1 },
         contract: 150,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 1800,
         ko: 600,
@@ -522,8 +522,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 5,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -551,7 +551,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 21: 1 },
         contract: 150,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 3600,
         ko: 1200,
@@ -562,8 +562,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 5,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -591,7 +591,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 27: 1 },
         contract: 200,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 2000,
         ko: 670,
@@ -602,8 +602,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 5,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -631,7 +631,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 19: 1 },
         contract: 250,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 2600,
         ko: 870,
@@ -642,8 +642,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 5,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -671,7 +671,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 27: 1 },
         contract: 200,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 4000,
         ko: 1340,
@@ -682,8 +682,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 5,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -711,7 +711,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 10: 8 },
         contract: 0,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 60,
         ko: 20,
@@ -744,7 +744,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 12: 20 },
         contract: 100,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 900,
         ko: 300,
@@ -769,7 +769,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 18: 1 },
         contract: 100,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 1400,
         ko: 470,
@@ -780,8 +780,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 7,
             size: 100,
-            min: 1,
-            max: 8
+            levelModifier: 1,
+            sizeModifier: 8
           }
         ],
         secondaryRewards: [
@@ -808,7 +808,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 395: 8 },
         contract: 100,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 900,
         ko: 300,
@@ -839,7 +839,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 19: 1, 17: 1 },
         contract: 350,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 3800,
         ko: 1270,
@@ -850,24 +850,24 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 7,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           },
           {
             monsterId: 17,
             startingArea: 0,
             level: 7,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           },
           {
             monsterId: 21,
             startingArea: 0,
             level: 7,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -892,7 +892,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 15,
         ko: 5,
@@ -919,7 +919,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 15,
         ko: 5,
@@ -946,7 +946,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1 },
         contract: 250,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 2800,
         ko: 940,
@@ -957,8 +957,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 7,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -986,7 +986,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 25: 1 },
         contract: 300,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 3400,
         ko: 1140,
@@ -997,8 +997,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 7,
             size: 100,
-            min: 1,
-            max: 7
+            levelModifier: 1,
+            sizeModifier: 7
           }
         ],
         secondaryRewards: [
@@ -1029,7 +1029,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1 },
         contract: 250,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 5600,
         ko: 1870,
@@ -1040,8 +1040,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 7,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1067,7 +1067,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 136: 2 },
         contract: 200,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 2000,
         ko: 670,
@@ -1097,7 +1097,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 28: 1 },
         contract: 300,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 3000,
         ko: 1000,
@@ -1108,8 +1108,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 7,
             size: 100,
-            min: 0,
-            max: 6
+            levelModifier: 0,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1139,7 +1139,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 14: 7 },
         contract: 100,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 900,
         ko: 300,
@@ -1168,7 +1168,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 350: 2 },
         contract: 250,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 2500,
         ko: 840,
@@ -1199,7 +1199,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 29: 1 },
         contract: 400,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 7200,
         ko: 2400,
@@ -1210,8 +1210,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 9,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1242,7 +1242,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 396: 1 },
         contract: 0,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 15,
         ko: 5,
@@ -1269,7 +1269,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 23: 1 },
         contract: 450,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 4800,
         ko: 1600,
@@ -1280,8 +1280,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 11,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1310,7 +1310,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 26: 1 },
         contract: 450,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 4800,
         ko: 1600,
@@ -1321,8 +1321,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 11,
             size: 100,
-            min: 1,
-            max: 7
+            levelModifier: 1,
+            sizeModifier: 7
           }
         ],
         secondaryRewards: [
@@ -1350,7 +1350,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 24: 1 },
         contract: 550,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 5600,
         ko: 1870,
@@ -1361,8 +1361,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 11,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1389,7 +1389,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 23: 1 },
         contract: 450,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 5200,
         ko: 1740,
@@ -1400,8 +1400,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 11,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1432,7 +1432,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 30: 1 },
         contract: 600,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 6000,
         ko: 2000,
@@ -1443,8 +1443,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 13,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1473,7 +1473,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 20: 1 },
         contract: 550,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 5600,
         ko: 1870,
@@ -1484,8 +1484,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 11,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1512,7 +1512,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 20: 1 },
         contract: 550,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 8600,
         ko: 2870,
@@ -1523,8 +1523,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 11,
             size: 100,
-            min: 1,
-            max: 6
+            levelModifier: 1,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1550,7 +1550,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 29: 50 },
         contract: 200,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 2100,
         ko: 700,
@@ -1561,8 +1561,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 2,
             level: 9,
             size: 100,
-            min: 0,
-            max: 6
+            levelModifier: 0,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1586,7 +1586,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 29: 1 },
         contract: 400,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 4200,
         ko: 1400,
@@ -1597,8 +1597,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 9,
             size: 100,
-            min: 0,
-            max: 6
+            levelModifier: 0,
+            sizeModifier: 6
           }
         ],
         secondaryRewards: [
@@ -1627,7 +1627,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 22: 1, 23: 1 },
         contract: 750,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 7600,
         ko: 2540,
@@ -1638,16 +1638,16 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 16,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           },
           {
             monsterId: 23,
             startingArea: 1,
             level: 16,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           }
         ],
         secondaryRewards: [
@@ -1670,7 +1670,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 24: 2 },
         contract: 1100,
         time: 50,
-        location: MapLocation.SANDY_PLAINS,
+        location: MapLocation.SandyPlains,
         randomspawn: false,
         reward: 11200,
         ko: 3740,
@@ -1681,16 +1681,16 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 16,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           },
           {
             monsterId: 24,
             startingArea: 1,
             level: 16,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           }
         ],
         secondaryRewards: [
@@ -1713,7 +1713,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 27: 1, 28: 1 },
         contract: 600,
         time: 50,
-        location: MapLocation.FLOODED_FOREST,
+        location: MapLocation.FloodedForest,
         randomspawn: false,
         reward: 6000,
         ko: 2000,
@@ -1724,16 +1724,16 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 1,
             level: 17,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           },
           {
             monsterId: 28,
             startingArea: 0,
             level: 18,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           }
         ],
         secondaryRewards: [
@@ -1756,7 +1756,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 26: 2 },
         contract: 950,
         time: 50,
-        location: MapLocation.TUNDRA,
+        location: MapLocation.Tundra,
         randomspawn: false,
         reward: 9600,
         ko: 3200,
@@ -1767,16 +1767,16 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 2,
             level: 16,
             size: 100,
-            min: 0,
-            max: 7
+            levelModifier: 0,
+            sizeModifier: 7
           },
           {
             monsterId: 26,
             startingArea: 1,
             level: 16,
             size: 100,
-            min: 0,
-            max: 7
+            levelModifier: 0,
+            sizeModifier: 7
           }
         ],
         secondaryRewards: [
@@ -1799,7 +1799,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 29: 1, 23: 1 },
         contract: 900,
         time: 50,
-        location: MapLocation.DESERTED_ISLAND,
+        location: MapLocation.DesertedIsland,
         randomspawn: false,
         reward: 9000,
         ko: 3000,
@@ -1810,16 +1810,16 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 18,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           },
           {
             monsterId: 23,
             startingArea: 1,
             level: 18,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           }
         ],
         secondaryRewards: [
@@ -1842,7 +1842,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 20: 1, 30: 1 },
         contract: 1100,
         time: 50,
-        location: MapLocation.VOLCANO,
+        location: MapLocation.Volcano,
         randomspawn: false,
         reward: 11600,
         ko: 3870,
@@ -1853,16 +1853,16 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 17,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           },
           {
             monsterId: 30,
             startingArea: 1,
             level: 17,
             size: 100,
-            min: 0,
-            max: 9
+            levelModifier: 0,
+            sizeModifier: 9
           }
         ],
         secondaryRewards: [
@@ -1885,7 +1885,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 22: 0 },
         contract: 600,
         time: 35,
-        location: MapLocation.UNDERWATER_RUIN,
+        location: MapLocation.UnderwaterRuin,
         randomspawn: false,
         reward: 6000,
         ko: 2000,
@@ -1896,8 +1896,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 16,
             size: 100,
-            min: 0,
-            max: 0
+            levelModifier: 0,
+            sizeModifier: 0
           }
         ],
         secondaryRewards: []
@@ -1913,7 +1913,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
         targets: { 31: 1 },
         contract: 1200,
         time: 30,
-        location: MapLocation.UNDERWATER_RUIN,
+        location: MapLocation.UnderwaterRuin,
         randomspawn: false,
         reward: 12000,
         ko: 4000,
@@ -1924,8 +1924,8 @@ export const VillageQuestData = deepFreeze<QuestMode>({
             startingArea: 0,
             level: 17,
             size: 100,
-            min: 0,
-            max: 0
+            levelModifier: 0,
+            sizeModifier: 0
           }
         ],
         secondaryRewards: [
@@ -1950,13 +1950,20 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 17: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 500,
       ko: 180,
       hrp: 0,
       bosses: [
-        { monsterId: 17, startingArea: 0, level: 23, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 17,
+          startingArea: 0,
+          level: 23,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -1971,13 +1978,20 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 21: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 500,
       ko: 180,
       hrp: 0,
       bosses: [
-        { monsterId: 21, startingArea: 0, level: 23, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 21,
+          startingArea: 0,
+          level: 23,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -1992,13 +2006,20 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 19: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 1000,
       ko: 200,
       hrp: 0,
       bosses: [
-        { monsterId: 19, startingArea: 0, level: 23, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 19,
+          startingArea: 0,
+          level: 23,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -2013,13 +2034,20 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 27: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.WATER_ARENA,
+      location: MapLocation.WaterArena,
       randomspawn: false,
       reward: 1000,
       ko: 200,
       hrp: 0,
       bosses: [
-        { monsterId: 27, startingArea: 0, level: 23, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 27,
+          startingArea: 0,
+          level: 23,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -2034,13 +2062,20 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 22: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 1000,
       ko: 200,
       hrp: 0,
       bosses: [
-        { monsterId: 22, startingArea: 0, level: 26, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 22,
+          startingArea: 0,
+          level: 26,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -2055,13 +2090,20 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 29: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.WATER_ARENA,
+      location: MapLocation.WaterArena,
       randomspawn: false,
       reward: 1500,
       ko: 220,
       hrp: 0,
       bosses: [
-        { monsterId: 29, startingArea: 0, level: 23, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 29,
+          startingArea: 0,
+          level: 23,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -2076,13 +2118,20 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 20: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 1500,
       ko: 220,
       hrp: 0,
       bosses: [
-        { monsterId: 20, startingArea: 0, level: 23, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 20,
+          startingArea: 0,
+          level: 23,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -2097,7 +2146,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 22: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 2000,
       ko: 230,
@@ -2108,10 +2157,17 @@ export const VillageQuestData = deepFreeze<QuestMode>({
           startingArea: 0,
           level: 36,
           size: 100,
-          min: 0,
-          max: 0
+          levelModifier: 0,
+          sizeModifier: 0
         },
-        { monsterId: 23, startingArea: 1, level: 37, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 23,
+          startingArea: 1,
+          level: 37,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -2126,7 +2182,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 28: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.WATER_ARENA,
+      location: MapLocation.WaterArena,
       randomspawn: false,
       reward: 2000,
       ko: 230,
@@ -2137,10 +2193,17 @@ export const VillageQuestData = deepFreeze<QuestMode>({
           startingArea: 0,
           level: 39,
           size: 100,
-          min: 0,
-          max: 0
+          levelModifier: 0,
+          sizeModifier: 0
         },
-        { monsterId: 29, startingArea: 1, level: 36, size: 100, min: 0, max: 0 }
+        {
+          monsterId: 29,
+          startingArea: 1,
+          level: 36,
+          size: 100,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     },
@@ -2155,7 +2218,7 @@ export const VillageQuestData = deepFreeze<QuestMode>({
       targets: { 19: 1 },
       contract: 0,
       time: 50,
-      location: MapLocation.LAND_ARENA,
+      location: MapLocation.LandArena,
       randomspawn: false,
       reward: 3000,
       ko: 350,
@@ -2166,18 +2229,25 @@ export const VillageQuestData = deepFreeze<QuestMode>({
           startingArea: 1,
           level: 36,
           size: 100,
-          min: 0,
-          max: 0
+          levelModifier: 0,
+          sizeModifier: 0
         },
         {
           monsterId: 26,
           startingArea: 1,
           level: 36,
           size: 100,
-          min: 0,
-          max: 0
+          levelModifier: 0,
+          sizeModifier: 0
         },
-        { monsterId: 23, startingArea: 0, level: 38, size: 115, min: 0, max: 0 }
+        {
+          monsterId: 23,
+          startingArea: 0,
+          level: 38,
+          size: 115,
+          levelModifier: 0,
+          sizeModifier: 0
+        }
       ],
       secondaryRewards: []
     }

--- a/src/model/weapons/weapon-util.ts
+++ b/src/model/weapons/weapon-util.ts
@@ -60,12 +60,12 @@ export function getWeapon(weaponClass: WeaponClass, weaponId: number): Weapon {
       break;
     }
     default: {
-      throw new Error(`${weaponClass} is not a valid weapon type`);
+      throw new Error(`'${weaponClass}' is not a valid weapon type`);
     }
   }
   if (!weapon)
     throw new Error(
-      `Could not find weapon of type '${weaponClass}' with id: ${weaponId}`
+      `Could not find weapon of type ''${weaponClass}'' with id: '${weaponId}'`
     );
   return weapon;
 }
@@ -120,6 +120,6 @@ export function sharpnessAsString(sharpness: Sharpness) {
     case Sharpness.PURPLE:
       return 'purple';
     default:
-      throw new Error(`Invalid sharpness value ${sharpness}`);
+      throw new Error(`Invalid sharpness value '${sharpness}'`);
   }
 }

--- a/tests/damage/damage.test.ts
+++ b/tests/damage/damage.test.ts
@@ -6,7 +6,10 @@ import {
   SwitchAxeDamageArgs,
   SwordAndShieldDamageArgs
 } from '../../src/damage/types';
-import { getMonsterMultipliersForQuest } from '../../src/model/monster-levels';
+import {
+  getMonsterLevelsForQuest,
+  getMonsterStatMultipliers
+} from '../../src/model/monster-levels';
 import {
   Alatreon,
   Deviljho,
@@ -18,14 +21,19 @@ import { Sharpness, WeaponClass } from '../../src/model/weapons';
 describe('Damage', () => {
   describe('calculateDamage', () => {
     const theBrilliantDarknessId = 0x4a39;
-    const brilliantDarknessModifiers = getMonsterMultipliersForQuest(
+    const alatreonLevels = getMonsterLevelsForQuest(
       Alatreon.name,
       theBrilliantDarknessId
     );
 
+    const brilliantDarknessModifiers = getMonsterStatMultipliers(
+      Alatreon.name,
+      alatreonLevels[0]
+    );
+
     const alatreonMonsterArgs: DamageTypes.MonsterArgs = {
       monsterName: Alatreon.name,
-      monsterStatMultipliers: brilliantDarknessModifiers[0],
+      monsterStatMultipliers: brilliantDarknessModifiers,
       monsterStateIndex: 0,
       hitzoneIndex: 0
     };
@@ -119,10 +127,17 @@ describe('Damage', () => {
 
       it('Modified impact hitzone', () => {
         const saveOurBoatId = 0x0402;
-        const saveOurBoatModifiers = getMonsterMultipliersForQuest(
+
+        const royalLudrothLevels = getMonsterLevelsForQuest(
           RoyalLudroth.name,
           saveOurBoatId
         );
+
+        const saveOurBoatModifiers = getMonsterStatMultipliers(
+          RoyalLudroth.name,
+          royalLudrothLevels[0]
+        );
+
         const damage = calculateDamage(
           {
             weaponClass: WeaponClass.LANCE,
@@ -133,7 +148,7 @@ describe('Damage', () => {
           },
           {
             monsterName: RoyalLudroth.name,
-            monsterStatMultipliers: saveOurBoatModifiers[0],
+            monsterStatMultipliers: saveOurBoatModifiers,
             monsterStateIndex: 0,
             hitzoneIndex: 0
           },
@@ -273,9 +288,15 @@ describe('Damage', () => {
 
       it('Deviljho Spirit Gauge RED', () => {
         const bedevilADeviljhoId = 0x3afd;
-        const bedevilADeviljhoMultipliers = getMonsterMultipliersForQuest(
+
+        const deviljhoLevels = getMonsterLevelsForQuest(
           Deviljho.name,
           bedevilADeviljhoId
+        );
+
+        const bedevilADeviljhoMultipliers = getMonsterStatMultipliers(
+          Deviljho.name,
+          deviljhoLevels[0]
         );
 
         const damage = calculateDamage(
@@ -294,7 +315,7 @@ describe('Damage', () => {
           },
           {
             monsterName: Deviljho.name,
-            monsterStatMultipliers: bedevilADeviljhoMultipliers[0],
+            monsterStatMultipliers: bedevilADeviljhoMultipliers,
             monsterStateIndex: 1, // rage
             hitzoneIndex: 1 // Stomach
           },
@@ -433,14 +454,19 @@ describe('Damage', () => {
           might: 'none'
         };
 
-        const royalRumbleMultipliers = getMonsterMultipliersForQuest(
+        const rathianLevels = getMonsterLevelsForQuest(
           Rathian.name,
           0x040e // A Royal Rumble
         );
 
+        const royalRumbleMultipliers = getMonsterStatMultipliers(
+          Rathian.name,
+          rathianLevels[0]
+        );
+
         const rathianMonsterArgs: DamageTypes.MonsterArgs = {
           monsterName: Rathian.name,
-          monsterStatMultipliers: royalRumbleMultipliers[0],
+          monsterStatMultipliers: royalRumbleMultipliers,
           monsterStateIndex: 0,
           hitzoneIndex: 0 // Head
         };

--- a/tests/damage/damage.test.ts
+++ b/tests/damage/damage.test.ts
@@ -1,4 +1,12 @@
+import type { DamageTypes } from '../../src/damage';
 import { calculateDamage } from '../../src/damage/damage';
+import {
+  DamageBuffArgs,
+  LongswordDamageArgs,
+  SwitchAxeDamageArgs,
+  SwordAndShieldDamageArgs
+} from '../../src/damage/types';
+import { getMonsterMultipliersForQuest } from '../../src/model/monster-levels';
 import {
   Alatreon,
   Deviljho,
@@ -6,20 +14,18 @@ import {
   RoyalLudroth
 } from '../../src/model/monsters/large-monster-data';
 import { Sharpness, WeaponClass } from '../../src/model/weapons';
-import type { DamageTypes } from '../../src/damage';
-import {
-  DamageBuffArgs,
-  LongswordDamageArgs,
-  SwitchAxeDamageArgs,
-  SwordAndShieldDamageArgs
-} from '../../src/damage/types';
 
 describe('Damage', () => {
   describe('calculateDamage', () => {
     const theBrilliantDarknessId = 0x4a39;
+    const brilliantDarknessModifiers = getMonsterMultipliersForQuest(
+      Alatreon.name,
+      theBrilliantDarknessId
+    );
+
     const alatreonMonsterArgs: DamageTypes.MonsterArgs = {
       monsterName: Alatreon.name,
-      questId: theBrilliantDarknessId,
+      monsterStatMultipliers: brilliantDarknessModifiers[0],
       monsterStateIndex: 0,
       hitzoneIndex: 0
     };
@@ -113,6 +119,10 @@ describe('Damage', () => {
 
       it('Modified impact hitzone', () => {
         const saveOurBoatId = 0x0402;
+        const saveOurBoatModifiers = getMonsterMultipliersForQuest(
+          RoyalLudroth.name,
+          saveOurBoatId
+        );
         const damage = calculateDamage(
           {
             weaponClass: WeaponClass.LANCE,
@@ -123,7 +133,7 @@ describe('Damage', () => {
           },
           {
             monsterName: RoyalLudroth.name,
-            questId: saveOurBoatId,
+            monsterStatMultipliers: saveOurBoatModifiers[0],
             monsterStateIndex: 0,
             hitzoneIndex: 0
           },
@@ -263,6 +273,10 @@ describe('Damage', () => {
 
       it('Deviljho Spirit Gauge RED', () => {
         const bedevilADeviljhoId = 0x3afd;
+        const bedevilADeviljhoMultipliers = getMonsterMultipliersForQuest(
+          Deviljho.name,
+          bedevilADeviljhoId
+        );
 
         const damage = calculateDamage(
           {
@@ -280,7 +294,7 @@ describe('Damage', () => {
           },
           {
             monsterName: Deviljho.name,
-            questId: bedevilADeviljhoId,
+            monsterStatMultipliers: bedevilADeviljhoMultipliers[0],
             monsterStateIndex: 1, // rage
             hitzoneIndex: 1 // Stomach
           },
@@ -306,12 +320,7 @@ describe('Damage', () => {
               sharpness: Sharpness.WHITE,
               weaponMultipliers: {} as SwitchAxeDamageArgs['weaponMultipliers']
             },
-            {
-              monsterName: Alatreon.name,
-              questId: theBrilliantDarknessId,
-              monsterStateIndex: 0,
-              hitzoneIndex: 0
-            },
+            alatreonMonsterArgs,
             {
               elementArgs: {
                 awaken: false,
@@ -424,9 +433,14 @@ describe('Damage', () => {
           might: 'none'
         };
 
+        const royalRumbleMultipliers = getMonsterMultipliersForQuest(
+          Rathian.name,
+          0x040e // A Royal Rumble
+        );
+
         const rathianMonsterArgs: DamageTypes.MonsterArgs = {
           monsterName: Rathian.name,
-          questId: 0x040e, // A Royal Rumble
+          monsterStatMultipliers: royalRumbleMultipliers[0],
           monsterStateIndex: 0,
           hitzoneIndex: 0 // Head
         };

--- a/tests/model/monster-levels/monster-level-util.test.ts
+++ b/tests/model/monster-levels/monster-level-util.test.ts
@@ -7,39 +7,39 @@ import {
   Ceadeus
 } from '../../../src/model/monsters/large-monster-data';
 describe('Monster Level utils', () => {
-  describe('getMonsterLevelMultipliers', () => {
+  describe('getMonsterStatMultipliers', () => {
     it('returns a multiplier object', () => {
       expect(
-        MonsterLevels.getMonsterLevelMultipliers(Deviljho.name, 3)
+        MonsterLevels.getMonsterStatMultipliers(Deviljho.name, 3)
       ).toBeDefined();
     });
     it('Elder Dragons should have a stagger multiplier of 1', () => {
-      const deviljhoMultipliers = MonsterLevels.getMonsterLevelMultipliers(
+      const deviljhoMultipliers = MonsterLevels.getMonsterStatMultipliers(
         Deviljho.name,
         52
       );
 
-      const ceadeusMultipliers = MonsterLevels.getMonsterLevelMultipliers(
+      const ceadeusMultipliers = MonsterLevels.getMonsterStatMultipliers(
         Ceadeus.name,
         17
       );
-      const jhenMultipliers = MonsterLevels.getMonsterLevelMultipliers(
+      const jhenMultipliers = MonsterLevels.getMonsterStatMultipliers(
         JhenMohran.name,
         30
       );
-      const alatreonMultipliers = MonsterLevels.getMonsterLevelMultipliers(
+      const alatreonMultipliers = MonsterLevels.getMonsterStatMultipliers(
         Alatreon.name,
         52
       );
 
-      expect(deviljhoMultipliers.stagger).toBe(2.2);
-      expect(ceadeusMultipliers.stagger).toBe(1);
-      expect(jhenMultipliers.stagger).toBe(1);
-      expect(alatreonMultipliers.stagger).toBe(1);
+      expect(deviljhoMultipliers[0].stagger).toBe(2.2);
+      expect(ceadeusMultipliers[0].stagger).toBe(1);
+      expect(jhenMultipliers[0].stagger).toBe(1);
+      expect(alatreonMultipliers[0].stagger).toBe(1);
     });
     it('throw error when invalid level provided', () => {
       expect(() =>
-        MonsterLevels.getMonsterLevelMultipliers(
+        MonsterLevels.getMonsterStatMultipliers(
           Deviljho.name,
           -1 as MonsterLevels.MonsterLevelTypes.MonsterLevel
         )
@@ -54,12 +54,14 @@ describe('Monster Level utils', () => {
       ).toThrow();
     });
 
-    it('Returns monster level multipliers', () => {
-      const expectedMultipliers: MonsterLevelTypes.MonsterLevelMultipliers = {
-        defense: 0.75,
-        health: [1],
-        stagger: 1
-      };
+    it('Returns monster stat multipliers', () => {
+      const expectedMultipliers: MonsterLevelTypes.MonsterStatMultipliers[] = [
+        {
+          defense: 0.75,
+          health: 1,
+          stagger: 1
+        }
+      ];
       expect(
         getMonsterMultipliersForQuest(Alatreon.name, 0x4a39)
       ).toStrictEqual(expectedMultipliers);

--- a/tests/model/monster-levels/monster-level-util.test.ts
+++ b/tests/model/monster-levels/monster-level-util.test.ts
@@ -1,12 +1,57 @@
 import { MonsterLevels, MonsterLevelTypes } from '../../../src/model';
-import { getMonsterMultipliersForQuest } from '../../../src/model/monster-levels';
+import {
+  getMonsterLevelRange,
+  getMonsterLevelsForQuest,
+  isValidMonsterLevel
+} from '../../../src/model/monster-levels';
 import {
   Deviljho,
   Alatreon,
   JhenMohran,
   Ceadeus
 } from '../../../src/model/monsters/large-monster-data';
+import { BossLevelModifiers } from '../../../src/model/quests';
 describe('Monster Level utils', () => {
+  describe('isValidMonsterLevel', () => {
+    it('Success with valid level', () => {
+      expect(() => isValidMonsterLevel(30)).not.toThrow();
+    });
+
+    it('Fails with invalid level', () => {
+      expect(() => isValidMonsterLevel(100)).toThrow();
+    });
+  });
+
+  describe('getMonsterLevelRange', () => {
+    it('returns 1 level for a FIXED modifier', () => {
+      const result = getMonsterLevelRange(10, BossLevelModifiers.Fixed);
+      expect(result).toHaveLength(1);
+    });
+
+    it('returns 3 levels for a PlusOne modifier', () => {
+      const result = getMonsterLevelRange(10, BossLevelModifiers.PlusOne);
+      expect(result).toHaveLength(3);
+    });
+
+    it('returns 5 levels for a PlusTwo modifier', () => {
+      const result = getMonsterLevelRange(10, BossLevelModifiers.PlusTwo);
+      expect(result).toHaveLength(5);
+    });
+
+    it('Throws error when given an invalid modifier', () => {
+      expect(() => getMonsterLevelRange(10, 5 as BossLevelModifiers)).toThrow();
+    });
+
+    it('Throws when given an invalid level', () => {
+      expect(() =>
+        getMonsterLevelRange(
+          100 as MonsterLevelTypes.MonsterLevel,
+          BossLevelModifiers.Fixed
+        )
+      ).toThrow();
+    });
+  });
+
   describe('getMonsterStatMultipliers', () => {
     it('returns a multiplier object', () => {
       expect(
@@ -32,10 +77,10 @@ describe('Monster Level utils', () => {
         52
       );
 
-      expect(deviljhoMultipliers[0].stagger).toBe(2.2);
-      expect(ceadeusMultipliers[0].stagger).toBe(1);
-      expect(jhenMultipliers[0].stagger).toBe(1);
-      expect(alatreonMultipliers[0].stagger).toBe(1);
+      expect(deviljhoMultipliers.stagger).toBe(2.2);
+      expect(ceadeusMultipliers.stagger).toBe(1);
+      expect(jhenMultipliers.stagger).toBe(1);
+      expect(alatreonMultipliers.stagger).toBe(1);
     });
     it('throw error when invalid level provided', () => {
       expect(() =>
@@ -47,24 +92,16 @@ describe('Monster Level utils', () => {
     });
   });
 
-  describe('getMonsterMultipliersForQuest', () => {
+  describe('getMonsterLevelsForQuest', () => {
     it('Throws error for invalid monster ID', () => {
-      expect(() =>
-        getMonsterMultipliersForQuest(Deviljho.name, 0x4a39)
-      ).toThrow();
+      expect(() => getMonsterLevelsForQuest(Deviljho.name, 0x4a39)).toThrow();
     });
 
-    it('Returns monster stat multipliers', () => {
-      const expectedMultipliers: MonsterLevelTypes.MonsterStatMultipliers[] = [
-        {
-          defense: 0.75,
-          health: 1,
-          stagger: 1
-        }
-      ];
-      expect(
-        getMonsterMultipliersForQuest(Alatreon.name, 0x4a39)
-      ).toStrictEqual(expectedMultipliers);
+    it('Returns monster levels', () => {
+      const expectedLevels: MonsterLevelTypes.MonsterLevel[] = [52];
+      expect(getMonsterLevelsForQuest(Alatreon.name, 0x4a39)).toStrictEqual(
+        expectedLevels
+      );
     });
   });
 });


### PR DESCRIPTION
Major update to the Monster Levels

- Levels `0-60` are now fully accounted-for
- HP and stagger multipliers verified ingame
  - Defense multipliers could still be suspect; they would need to be reversed out with controlled attacks ingame.
- Util functions reworked for `MonsterLevelTypes`
- New parameters for `calculateDamage` to accept a specific `MonsterStatMultipliers`
  - This will be a breaking change